### PR TITLE
Fixes Typos in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are currently sixteen flags included:
 - autism
 - bi (bisexual)
 - genderfluid
-- gerderqueer
+- genderqueer
 - intersex
 - lesbian
 - enby (non-binary)
@@ -38,7 +38,7 @@ There are currently sixteen flags included:
 - sapphic (a flag for all lesbians)
 - trans (transgender)
 
-You can request new cats via a [new issue on this repo](https://github.com/ZoeBijl/Gaysper/issues/new) or [message me on Mastodon](https://queer.garden/@moiety).
+You can request new ghosts via a [new issue on this repo](https://github.com/ZoeBijl/Gaysper/issues/new) or [message me on Mastodon](https://queer.garden/@moiety).
 
 ## File formats
 


### PR DESCRIPTION
Fixes a typo in "ge(r->n)derqueer" and "cats->ghosts" copy/paste oversight.